### PR TITLE
Moved github.com/willf/bitset import to github.com/bits-and-blooms/bitset

### DIFF
--- a/fst.go
+++ b/fst.go
@@ -17,7 +17,7 @@ package vellum
 import (
 	"io"
 
-	"github.com/willf/bitset"
+	"github.com/bits-and-blooms/bitset"
 )
 
 // FST is an in-memory representation of a finite state transducer,

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/blevesearch/vellum
 go 1.12
 
 require (
+	github.com/bits-and-blooms/bitset v1.1.10
 	github.com/blevesearch/mmap-go v1.0.2
 	github.com/spf13/cobra v0.0.5
-	github.com/willf/bitset v1.1.10
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/bits-and-blooms/bitset v1.1.10 h1:oTle449SfMfXO0BpZN1bMPe5SCRlQct8pX7siV30jGA=
+github.com/bits-and-blooms/bitset v1.1.10/go.mod h1:w0XsmFg8qg6cmpTtJ0z3pKgjTDBMMnI/+I2syrE6XBE=
 github.com/blevesearch/mmap-go v1.0.2 h1:JtMHb+FgQCTTYIhtMvimw15dJwu1Y5lrZDMOFXVWPk0=
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -27,8 +29,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
-github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=
-github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -34,8 +34,8 @@
 			"notests": true
 		},
 		{
-			"importpath": "github.com/willf/bitset",
-			"repository": "https://github.com/willf/bitset",
+			"importpath": "github.com/bits-and-blooms/bitset",
+			"repository": "https://github.com/bits-and-blooms/bitset",
 			"vcs": "git",
 			"revision": "5c3c0fce48842b2c0bbaa99b4e61b0175d84b47c",
 			"branch": "master",


### PR DESCRIPTION
This is a minor but critical change, as the bitset repo has been renamed, and using the legacy import still results in "module declares its path as: github.com/bits-and-blooms/bitset but was required as: github.com/willf/bitset" errors in some build systems. Specifically, this import has been causing issues when using Bazel and Go. 