### PR TITLE
Add ReusableState for allocation-free incremental FST walks

### DIFF
--- a/fst_reuse.go
+++ b/fst_reuse.go
@@ -1,0 +1,43 @@
+package vellum
+
+// ReusableState is an opaque, reusable decode buffer for the incremental
+// AcceptWithValState / IsMatchWithValState walk.
+//
+// The stock AcceptWithVal / IsMatchWithVal decode each source state with a nil
+// prealloc, so they allocate a fresh internal state on every transition. Callers
+// that walk the FST one byte at a time over many overlapping prefixes — e.g.
+// building a CJK segmentation DAG, where the walk restarts from every input
+// position — pay one allocation per transition. Holding a single ReusableState
+// for the whole walk eliminates that allocation (the internal state only
+// references the FST data, so it can be reused in place).
+//
+// A ReusableState is NOT safe for concurrent use; give each goroutine its own.
+type ReusableState struct {
+	s fstStateV1
+}
+
+// NewReusableState returns a fresh, reusable decode buffer.
+func NewReusableState() *ReusableState {
+	return &ReusableState{}
+}
+
+// AcceptWithValState behaves exactly like AcceptWithVal but decodes the source
+// state into the caller-owned rs instead of allocating a new internal state.
+func (f *FST) AcceptWithValState(addr int, b byte, rs *ReusableState) (int, uint64) {
+	s, err := f.decoder.stateAt(addr, &rs.s)
+	if err != nil {
+		return noneAddr, 0
+	}
+	_, next, output := s.TransitionFor(b)
+	return next, output
+}
+
+// IsMatchWithValState behaves exactly like IsMatchWithVal but decodes the state
+// into the caller-owned rs instead of allocating a new internal state.
+func (f *FST) IsMatchWithValState(addr int, rs *ReusableState) (bool, uint64) {
+	s, err := f.decoder.stateAt(addr, &rs.s)
+	if err != nil {
+		return false, 0
+	}
+	return s.Final(), s.FinalOutput()
+}

--- a/fst_reuse_test.go
+++ b/fst_reuse_test.go
@@ -1,0 +1,86 @@
+package vellum
+
+import (
+	"bytes"
+	"testing"
+)
+
+// buildTestFST builds a small FST from sorted keys with val = len(key).
+func buildTestFST(t *testing.T, keys []string) *FST {
+	t.Helper()
+	var buf bytes.Buffer
+	b, err := New(&buf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range keys {
+		if err := b.Insert([]byte(k), uint64(len(k))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := b.Close(); err != nil {
+		t.Fatal(err)
+	}
+	fst, err := Load(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fst
+}
+
+// walk consumes key one byte at a time, returning the accumulated output and
+// whether the final state matched. When rs != nil it uses the reusable-state
+// variants; otherwise the stock ones.
+func walk(fst *FST, key string, rs *ReusableState) (uint64, bool) {
+	addr := fst.Start()
+	var sum uint64
+	for i := 0; i < len(key); i++ {
+		var next int
+		var out uint64
+		if rs != nil {
+			next, out = fst.AcceptWithValState(addr, key[i], rs)
+		} else {
+			next, out = fst.AcceptWithVal(addr, key[i])
+		}
+		if next == noneAddr {
+			return 0, false
+		}
+		addr = next
+		sum += out
+	}
+	var final bool
+	var fout uint64
+	if rs != nil {
+		final, fout = fst.IsMatchWithValState(addr, rs)
+	} else {
+		final, fout = fst.IsMatchWithVal(addr)
+	}
+	return sum + fout, final
+}
+
+// TestReusableStateMatchesStock verifies the *State variants return identical
+// results to AcceptWithVal/IsMatchWithVal for matching, prefix, and absent keys.
+func TestReusableStateMatchesStock(t *testing.T) {
+	fst := buildTestFST(t, []string{"cat", "cats", "dog", "doge"})
+	rs := NewReusableState()
+	for _, k := range []string{"cat", "cats", "dog", "doge", "ca", "do", "zzz", "catx"} {
+		wantVal, wantFinal := walk(fst, k, nil)
+		gotVal, gotFinal := walk(fst, k, rs) // reuse rs across keys on purpose
+		if gotVal != wantVal || gotFinal != wantFinal {
+			t.Errorf("%q: state walk (%d,%v) != stock (%d,%v)", k, gotVal, gotFinal, wantVal, wantFinal)
+		}
+	}
+}
+
+// TestReusableStateNoAlloc asserts the reusable-state walk does not allocate per
+// transition (the whole point of the API).
+func TestReusableStateNoAlloc(t *testing.T) {
+	fst := buildTestFST(t, []string{"cat", "cats", "dog", "doge"})
+	rs := NewReusableState()
+	allocs := testing.AllocsPerRun(200, func() {
+		walk(fst, "cats", rs)
+	})
+	if allocs != 0 {
+		t.Errorf("reusable-state walk allocated %v objects/run, want 0", allocs)
+	}
+}


### PR DESCRIPTION
## Motivation

`AcceptWithVal` / `IsMatchWithVal` decode each source state with a `nil` prealloc, so they allocate a fresh `fstStateV1` on **every transition**. Callers that walk the FST one byte at a time over many overlapping prefixes — e.g. building a CJK segmentation DAG that restarts the walk from every input position — pay one allocation per transition.

In a real FST-backed CJK tokenizer (replacing a cedar-trie dictionary with a vellum FST), a memprofile showed `decoderV1.stateAt` accounting for **~69% of all allocations**; threading a reusable state removed them and made tokenization **~2× faster** wall-clock (allocs/op 1756→396, B/op 232K→22K).

## Change

`fstStateV1` only *references* the FST data (no owned slices), so a single reusable instance can back an entire walk. This PR adds:

- `ReusableState` — an opaque, caller-owned decode buffer (`NewReusableState()`).
- `AcceptWithValState(addr, b, rs)` and `IsMatchWithValState(addr, rs)` — identical behavior to the existing methods, but decode into `rs` instead of allocating.

The existing API is untouched; this is purely additive. A `ReusableState` is not safe for concurrent use (documented), matching the per-goroutine pattern of `Reader`.

## Tests

- `TestReusableStateMatchesStock` — the `*State` variants return identical `(output, final)` to `AcceptWithVal`/`IsMatchWithVal` across matching, prefix, and absent keys, reusing one `ReusableState` across keys.
- `TestReusableStateNoAlloc` — `testing.AllocsPerRun` of a full walk is `0`.

Disclosure: drafted with AI assistance; reviewed and tested locally (`go test` green, `gofmt` clean).